### PR TITLE
Sanitize inputs to prevent SQL injections

### DIFF
--- a/api/database/database.go
+++ b/api/database/database.go
@@ -2,15 +2,16 @@ package database
 
 import (
 	"database/sql"
-	_ "github.com/go-sql-driver/mysql"
 	"reflect"
 	"strings"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 var db *sql.DB
 
-func Query[T any](query_ string, arr *[]T) {
-	rows, err := db.Query(query_)
+func Query[T any](arr *[]T, query_ string, args ...any) {
+	rows, err := db.Query(query_, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -50,13 +51,13 @@ func Query[T any](query_ string, arr *[]T) {
 	}
 }
 
-func QueryValue[T any](query_ string, value *T) error {
-	err := db.QueryRow(query_).Scan(value)
+func QueryValue[T any](value *T, query_ string, args ...any) error {
+	err := db.QueryRow(query_, args...).Scan(value)
 	return err
 }
 
-func Execute(exec string) (sql.Result, error) {
-	result, err := db.Exec(exec)
+func Execute(exec string, args ...any) (sql.Result, error) {
+	result, err := db.Exec(exec, args...)
 	return result, err
 }
 

--- a/api/login/login.go
+++ b/api/login/login.go
@@ -30,7 +30,7 @@ func createAccount(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	result, err := database.Execute(fmt.Sprintf("INSERT INTO Accounts (email, password) VALUES ('%s', SHA2('%s', 256))", acc.Email, acc.Password))
+	result, err := database.Execute("INSERT INTO Accounts (email, password) VALUES (?, SHA2(?, 256))", acc.Email, acc.Password)
 	if err != nil {
 		return
 	}
@@ -44,7 +44,7 @@ func createAccount(response http.ResponseWriter, request *http.Request) {
 }
 
 func validateAccount(response http.ResponseWriter, request *http.Request) {
-	log.Println("Received request to /login/verifyAccount")
+	log.Println("Received request to /login/validateAccount")
 
 	status := false
 	defer func() {
@@ -58,7 +58,7 @@ func validateAccount(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	_ = database.QueryValue(fmt.Sprintf("SELECT SHA2('%s', 256)=password FROM Accounts WHERE email='%s'", acc.Password, acc.Email), &status)
+	_ = database.QueryValue(&status, "SELECT SHA2(?, 256)=password FROM Accounts WHERE email=?", acc.Password, acc.Email)
 }
 
 func HandleLoginRoutes(r *mux.Router) {


### PR DESCRIPTION
# Issue
Fix #52

# Description
Changed `api/database` to accept variadic parameters itself instead of using `Sprintf`, as recommended by Golang docs

# Type Of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test Steps
Ran command listed in #52, and now it returns `false`:

```bash
curl -X POST -H "Content-Type: application/json" \
    -d '{"email": "a'\'' OR 1=1 OR email='\''hello", "password": "hello"}' \
    localhost:8000/login/validateAccount
```

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
