### PR TITLE
Create OpenAPI docs

### DIFF
--- a/api/openapi-docs.yml
+++ b/api/openapi-docs.yml
@@ -1,0 +1,116 @@
+openapi: 3.0.3
+info:
+  title: Lunch Buddies
+  description: |-
+    An application that lets you find and match with like-minded students on campus to study, have a meal with, and more!
+
+  termsOfService: https://github.com/ufosc/Lunch_Buddies#readme
+  version: 0.0.1
+servers: 
+  - url: http://localhost:8000
+    description: Local development server
+tags:
+  - name: login
+    description: Logging in and creating accounts
+  - name: accounts
+    description: Modifying accounts
+  - name: messages
+    description: Managing messages
+paths:
+  /login/createAccount:
+    post:
+      tags:
+        - login
+      summary: Create a new account
+      description: Create a new account with an email and password
+      operationId: createAccount
+      requestBody:
+        description: Create a new account in the database
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Account'
+        required: true
+      responses:
+        '201':
+          description: Account successfully created 
+        '400':
+          description: Account not created
+  /login/validateAccount:
+    post:
+      tags:
+        - login
+      summary: Get a JWT token for an account
+      description: Get a JWT token for an account if the credentials are correct
+      operationId: validateAccount
+      requestBody:
+        description: Get a JWT token for an account
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Account'
+        required: true
+      responses:
+        '200':
+          description: Account validated
+          content:
+            text/plain:
+              schema:
+                description: The token
+                type: string
+                example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJMdW5jaEJ1ZGRpZXMiLCJzdWIiOiJ0ZXN0YWNjdDNAdWZsLmVkdSIsImV4cCI6MTY4MDEyODUxOSwiaWF0IjoxNjgwMDQyMTE5fQ._717r9pFqemMBAVzvVxi1Y4hmfaeDr3En8iYjqVWBnU
+        '401':
+          description: Incorrect credentials
+  /accounts/updateProfile:
+    post:
+      tags:
+        - accounts
+      summary: Update an account's profile
+      description: Update an account's profile
+      operationId: updateProfile
+      requestBody:
+        description: Update an account's profile
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountChanges'
+        required: true
+      responses:
+        '200':
+          description: Account successfully updated
+        '400':
+          description: Account not updated
+        '401':
+          description: Unauthorized
+      security:
+        - jwtToken: []
+      
+
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john.doe@ufl.edu
+        password:
+          type: string
+          example: ThisPasswordCouldBeImproved
+    AccountChanges:
+      type: object
+      properties:
+        firstName:
+          type: string
+          description: Leave blank if no change
+          example: John
+        lastName:
+          type: string
+          description: Leave blank if no change
+          example: Doe
+  
+  securitySchemes:
+    jwtToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
# Issue
Create more maintainable docs for the API, #46

# Description
Adds a `openapi-docs.yml` to create nicer docs for the backend. This is intended to replace `api/README.md` (it's not very easy to work with Markdown tables!)

<img width="1020" alt="Screenshot 2023-04-13 at 6 21 00 PM" src="https://user-images.githubusercontent.com/79120643/231895784-568bdebf-7459-4393-a714-ad4a24c6987c.png">

This currently doesn't entirely accurately reflect the actual behavior of the endpoints (e.g. most of them don't return different HTTP status codes based on the result; they probably should).

A process for actually building the docs (e.g. with GitHub Actions deploying to GitHub Pages) isn't done in this PR yet. There are VSCode extensions you can use to preview the docs, however ([example](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)). 

# Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test Steps
n/a

# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Formatting

Please use markdown in your pull request message. A useful summary of commands can be found [here](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf).
