### PR TITLE
Use salts for passwords in account creation and validation

### DIFF
--- a/api/database.sql
+++ b/api/database.sql
@@ -2,7 +2,8 @@ CREATE TABLE Accounts (
     email VARCHAR(50) PRIMARY KEY,
     firstName VARCHAR(50),
     lastName VARCHAR(50),
-    password CHAR(64) NOT NULL
+    password CHAR(64) NOT NULL,
+    salt CHAR(16) NOT NULL
 );
 CREATE TABLE Chats (
     id INTEGER PRIMARY KEY,


### PR DESCRIPTION
# Issue
Close #54 

# Description
Generate salts that are appended to the given password before hashing

(breaking change because it requires database changes)

# Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test Steps
Create and validate new accounts, observe different hashes in the database

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Formatting

Please use markdown in your pull request message. A useful summary of commands can be found [here](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf).
