### PR TITLE
Stop API startup if the database connection fails

### DIFF
--- a/api/database/database.go
+++ b/api/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"log"
 	"reflect"
 	"strings"
 
@@ -69,4 +70,8 @@ func InitDatabase(dbUrl string) {
 		panic(err)
 	}
 
+	err = db.Ping()
+	if err != nil {
+		log.Panicln("Could not connect to database. Check your .env file. Error details:\n", err)
+	}
 }


### PR DESCRIPTION
# Issue
If the database can't be connected to (e.g. it is not running or the `.env` file is set incorrectly), the API may still startup without any indication that the connection failed. This can lead to confusion if certain things don't work.

# Description
As the API is essentially useless without the database, it will panic on startup if the database connection fails. This seems to be the intention based on the surrounding code, but `sql.Open` doesn't actually give an error in this case because it doesn't necessarily create a connection immediately.

# Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test Steps
Start the API without the database active

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Formatting

Please use markdown in your pull request message. A useful summary of commands can be found [here](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf).
